### PR TITLE
Add JWS 5.6 imagestream for deprecated apiVersion identifiers

### DIFF
--- a/Parameters.md
+++ b/Parameters.md
@@ -39,7 +39,7 @@ Note that the file might contain several user/password or token to access to the
 
 ### webApp
 Describes how the operator will build the webapp to add to application image, if not present the application is just deployed.
-It has the sourceRepositoryUrl (Mandatory), sourceRepositoryRef, contextDir, webAppWarImage, webAppWarImagePushSecret,Name and builder. 
+It has the sourceRepositoryUrl (Mandatory), sourceRepositoryRef, contextDir, webAppWarImage, webAppWarImagePushSecret,Name and builder.
 
 ### webServerHealthCheck
 Describes how the operator will create the health check for the created pods.
@@ -53,18 +53,18 @@ It has the imageStreamName (Mandatory), imageStreamNamespace, webSources (might 
 The name of the image stream you created to allow the operator to find the base images.
 
 ```bash
-oc create -f xpaas-streams/jws54-tomcat9-image-stream.json
-imagestream.image.openshift.io/jboss-webserver54-tomcat9-openshift created
+oc create -f xpaas-streams/jws56-tomcat9-image-stream.json
+imagestream.image.openshift.io/jboss-webserver56-tomcat9-openshift created
 ```
 
-Here: imageStream: `jboss-webserver54-tomcat9-openshift:latest`
+Here: imageStream: `jboss-webserver56-tomcat9-openshift:latest`
 
 ### imageStreamNamespace
 The namespace/project in which you created the image stream
 
 ```bash
-oc create -f xpaas-streams/jws54-tomcat9-image-stream.json -n jfc
-imagestream.image.openshift.io/jboss-webserver54-tomcat9-openshift created
+oc create -f xpaas-streams/jws56-tomcat9-image-stream.json -n jfc
+imagestream.image.openshift.io/jboss-webserver56-tomcat9-openshift created
 ```
 
 Here: imageStreamNamespace: jfc

--- a/QuickStart.md
+++ b/QuickStart.md
@@ -4,7 +4,7 @@ The JWS operator brings two main features, deploy a prepared image or build an i
 
 You have to prepare an image with the health check valve or any other way to check that the webapp you want to deploy is running.
 
-The JWS-5.4 image has the Apache Tomcat health check valve already configured.
+The JWS-5.6 image has the Apache Tomcat health check valve already configured.
 
 If you are building your image from the ASF Tomcat
 make sure you have the health check valve enabled in the server.xml.
@@ -37,15 +37,15 @@ The operator will deploy 2 pods running the image docker.io/jfclere/tomcat-demo,
 
 The route is something like http://jws-app-jws-operator.example.[cluster base name]/
 
-## Build a image base on JWS-5.4 and deploy it
+## Build a image base on JWS-5.6 and deploy it
 
 If you want to use an image stream, use a file with something like in the following file:
 https://github.com/web-servers/jws-operator/blob/master/xpaas-streams/jws54-tomcat9-image-stream.json
 
-This creates the image stream jboss-webserver54-openjdk8-tomcat9-ubi8-openshift:
+This creates the image stream jboss-webserver56-openjdk8-tomcat9-openshift-ubi8:
 
 ```
-oc create -f https://github.com/web-servers/jws-operator/blob/master/xpaas-streams/jws54-tomcat9-image-stream.json
+oc create -f https://github.com/web-servers/jws-operator/blob/master/xpaas-streams/jws56-tomcat9-image-stream.json
 ```
 
 Prepare you webapps to build with mvn install, put it in a git URL that your cluster can access, then create a minimal yaml file like the following
@@ -60,7 +60,7 @@ spec:
   replicas: 2
   webImageStream:
     imageStreamNamespace: openshift
-    imageStreamName: jboss-webserver54-openjdk8-tomcat9-ubi8-openshift
+    imageStreamName: jboss-webserver56-openjdk8-tomcat9-openshift-ubi8
     webSources:
       sourceRepositoryUrl: https://github.com/jboss-openshift/openshift-quickstarts.git
       sourceRepositoryRef: "1.2"

--- a/xpaas-streams/jws56-tomcat9-image-stream.json
+++ b/xpaas-streams/jws56-tomcat9-image-stream.json
@@ -1,0 +1,49 @@
+{
+    "kind": "List",
+    "apiVersion": "v1",
+    "metadata": {
+        "name": "webserver56-openjdk8-tomcat9-ubi8-image-stream",
+        "annotations": {
+            "description": "ImageStream definition for Red Hat JBoss Web Server 5.6 Apache Tomcat 9 OpenJDK8 on UBI8.",
+            "openshift.io/provider-display-name": "Red Hat, Inc."
+        }
+    },
+    "items": [
+        {
+            "kind": "ImageStream",
+            "apiVersion": "image.openshift.io/v1",
+            "metadata": {
+                "name": "jboss-webserver56-openjdk8-tomcat9-openshift-ubi8",
+                "annotations": {
+                    "openshift.io/display-name": "JBoss Web Server 5.6 Apache Tomcat 9 OpenJDK8 on UBI8",
+                    "openshift.io/provider-display-name": "Red Hat, Inc.",
+                    "version": "5.6"
+                }
+            },
+            "spec": {
+                "tags": [
+                    {
+                        "name": "latest",
+                        "annotations": {
+                            "description": "JBoss Web Server 5.6 Apache Tomcat 9 OpenJDK8 on UBI8 S2I images.",
+                            "iconClass": "icon-rh-tomcat",
+                            "tags": "builder,tomcat,tomcat9,java,jboss,hidden",
+                            "supports": "tomcat9:5.6,tomcat:9,java:8",
+                            "sampleRepo": "https://github.com/jboss-openshift/openshift-quickstarts.git",
+                            "sampleContextDir": "tomcat-websocket-chat",
+                            "version": "latest",
+                            "openshift.io/display-name": "JBoss Web Server 5.6 Apache Tomcat 9 OpenJDK8 on UBI8"
+                        },
+			"referencePolicy": {
+                            "type": "Local"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.redhat.io/jboss-webserver-5/jws56-openjdk8-openshift-rhel8:latest"
+                        }
+                    }
+                ]
+            }
+        }
+    ]
+}


### PR DESCRIPTION
This PR adds the JWS 5.6 imagestream which drops the deprecated usage of non-groupified apiVersion identifiers.
Relates to https://issues.redhat.com/browse/JWS-2464 .