### PR TITLE
Arrange the RoleBinding view detection for KUBEPing.

### DIFF
--- a/controllers/templates.go
+++ b/controllers/templates.go
@@ -73,7 +73,7 @@ func (r *WebServerReconciler) generateRoleBinding(webServer *webserversv1alpha1.
 		RoleRef: rbac.RoleRef{
 			APIGroup: "rbac.authorization.k8s.io",
 			Kind:     "ClusterRole",
-			Name:     "view-kubeping-" + webServer.Name,
+			Name:     "view",
 		},
 		Subjects: []rbac.Subject{{
 			Kind:      "ServiceAccount",

--- a/controllers/templates.go
+++ b/controllers/templates.go
@@ -73,7 +73,7 @@ func (r *WebServerReconciler) generateRoleBinding(webServer *webserversv1alpha1.
 		RoleRef: rbac.RoleRef{
 			APIGroup: "rbac.authorization.k8s.io",
 			Kind:     "ClusterRole",
-			Name:     "view",
+			Name:     "view-kubeping-" + webServer.Name,
 		},
 		Subjects: []rbac.Subject{{
 			Kind:      "ServiceAccount",

--- a/controllers/webserver_controller.go
+++ b/controllers/webserver_controller.go
@@ -186,12 +186,13 @@ func (r *WebServerReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		if r.needgetUseKUBEPing(webServer) {
 
 			// Check if a RoleBinding for the KUBEPing exists, and if not create one.
-			rolebinding := r.generateRoleBinding(webServer, "view")
+			rolename := "view-kubeping-" + webServer.Name
+			rolebinding := r.generateRoleBinding(webServer, rolename)
 			//
 			// The example in docs seems to use view (name: view and roleRef ClusterRole/view for our ServiceAccount)
 			// like:
 			// oc policy add-role-to-user view system:serviceaccount:tomcat-in-the-cloud:default -n tomcat-in-the-cloud
-			useKUBEPing, update, err := r.createRoleBinding(ctx, webServer, rolebinding, "view", rolebinding.Namespace)
+			useKUBEPing, update, err := r.createRoleBinding(ctx, webServer, rolebinding, rolename, rolebinding.Namespace)
 			if !useKUBEPing {
 				// Update the webServer annotation to prevent retrying
 				log.Info("Won't use KUBEPing missing view permissions")


### PR DESCRIPTION
Basically we look for something like:
+++
apiVersion: rbac.authorization.k8s.io/v1
kind: RoleBinding
metadata:
  creationTimestamp: "2022-05-30T09:58:14Z"
  name: view-3
  namespace: jclere-namespace
  resourceVersion: "30149839"
  uid: 24f1112e-ed73-4d37-a23b-7a613b7599af
roleRef:
  apiGroup: rbac.authorization.k8s.io
  kind: ClusterRole
  name: view
subjects:
- kind: ServiceAccount
  name: default
  namespace: jclere-namespace
+++
If we have it and it is not view-kubeping-... The operator will tell the JWS/tomcat pod to use KUBEPing.
Otherwise we try to create the RoleBinding, which might fail because the operator might not have the permission.