### PR TITLE
server.xml configuration

### DIFF
--- a/api/v1alpha1/webserver_types.go
+++ b/api/v1alpha1/webserver_types.go
@@ -24,6 +24,8 @@ type WebServerSpec struct {
 	UseSessionClustering bool `json:"useSessionClustering,omitempty"`
 	// Route behaviour:[TLS/tls]hostname/NONE or empty.
 	RouteHostname string `json:"routeHostname,omitempty"`
+	// IsNotJWS boolean that specifies if the image is JWS or not.
+	IsNotJWS bool `json:"isNotJWS,omitempty"`
 	// TLSSecret secret containing server.cert the server certificate, server.key the server key and optional ca.cert the CA cert of the client certificates
 	TLSSecret string `json:"tlsSecret,omitempty"`
 	// TLSPassword passphrase for the key in the client.key

--- a/controllers/templates.go
+++ b/controllers/templates.go
@@ -754,7 +754,7 @@ func (r *WebServerReconciler) generateVolumePodBuilder(webServer *webserversv1al
 func (r *WebServerReconciler) generateCommandForServerXml(webServer *webserversv1alpha1.WebServer) map[string]string {
 	cmd := make(map[string]string)
 	connector := ""
-	if strings.HasPrefix(webServer.Spec.RouteHostname, "TLS") || strings.HasPrefix(webServer.Spec.RouteHostname, "tls") {
+	if webServer.Spec.IsNotJWS && (strings.HasPrefix(webServer.Spec.RouteHostname, "TLS") || strings.HasPrefix(webServer.Spec.RouteHostname, "tls")) {
 		// "/tls" is the dir in which the secret's contents are mounted to the pod
 		connector =
 			"https=\"<!-- No HTTPS configuration discovered -->\"\n" +


### PR DESCRIPTION
IsNotJWS defines if the deployed image is a JWS one or not. If it is, the configuration is executed inside the image https://github.com/web-servers/jboss-jws-container-images-modules/pull/12/files , otherwise operator configures the server.xml

Cotnributes to: https://github.com/web-servers/jws-operator/issues/84

Signed-off: [vmouriki@gmail.com](mailto:vmouriki@gmail.com)