### PR TITLE
sorted labels fix

### DIFF
--- a/controllers/helper.go
+++ b/controllers/helper.go
@@ -525,9 +525,19 @@ func (r *WebServerReconciler) getWebServerHash(webServer *webserversv1alpha1.Web
 
 	/* add the labels */
 	if webServer.ObjectMeta.Labels != nil {
-		for labelKey, labelValue := range webServer.ObjectMeta.Labels {
-			h.Write([]byte(labelKey + ":" + labelValue))
+		keys := make([]string, len(webServer.ObjectMeta.Labels))
+		i := 0
+		for k := range webServer.ObjectMeta.Labels {
+			keys[i] = k
+			i++
 		}
+		sort.Strings(keys)
+
+		// To perform the opertion you want
+		for _, k := range keys {
+			h.Write([]byte(k + ":" + webServer.ObjectMeta.Labels[k]))
+		}
+
 	}
 	if webServer.Spec.WebImage != nil {
 		/* Same for WebImage */

--- a/controllers/label_test.go
+++ b/controllers/label_test.go
@@ -105,7 +105,11 @@ var _ = Describe("WebServer controller", func() {
 			Expect(deployment.Spec.Template.GetLabels()["ready"]).Should(Equal("oui"))
 
 			newLabels := map[string]string{
-				"ready": "non",
+				"ready":  "non",
+				"ready1": "non1",
+				"ready2": "non2",
+				"ready3": "non3",
+				"ready4": "non4",
 			}
 			createdWebserver.ObjectMeta.SetLabels(newLabels)
 
@@ -148,8 +152,7 @@ var _ = Describe("WebServer controller", func() {
 					podList := &corev1.PodList{}
 
 					labels := map[string]string{
-						"WebServer": webserver.Name,
-						"ready":     "non",
+						"ready": "non",
 					}
 
 					listOpts := []client.ListOption{
@@ -236,7 +239,11 @@ var _ = Describe("WebServer controller", func() {
 				Expect(deployment.Spec.Template.GetLabels()["ready"]).Should(Equal("oui"))
 
 				newLabels := map[string]string{
-					"ready": "non",
+					"ready":  "non",
+					"ready1": "non1",
+					"ready2": "non2",
+					"ready3": "non3",
+					"ready4": "non4",
 				}
 				webserver.ObjectMeta.SetLabels(newLabels)
 
@@ -278,8 +285,7 @@ var _ = Describe("WebServer controller", func() {
 						podList := &corev1.PodList{}
 
 						labels := map[string]string{
-							"WebServer": webserver.Name,
-							"ready":     "non",
+							"ready": "non",
 						}
 
 						listOpts := []client.ListOption{


### PR DESCRIPTION
Fix for [[JWS-2555](https://issues.redhat.com/browse/JWS-2555)] . Instead of hashing the map with the labels, we first insert them to a slice and sort it in order to get the same hash every time. Fixed label_test.go as needed too.

Signed-off: [vmouriki@redhat.com](mailto:vmouriki@redhat.com)