### PR TITLE
Save catalina.out in a PV

### DIFF
--- a/api/v1alpha1/webserver_types.go
+++ b/api/v1alpha1/webserver_types.go
@@ -34,6 +34,8 @@ type WebServerSpec struct {
 	WebImageStream *WebImageStreamSpec `json:"webImageStream,omitempty"`
 	// Configuration of the resources used by the WebServer, ie CPU and memory, use limits and requests
 	Resources *corev1.ResourceRequirements `json:"resources,omitempty"`
+	//If true operator will create a PVC to save the logs.
+	PersistentLogs bool `json:"persistentLogs,omitempty"`
 }
 
 // (Deployment method 1) Application image

--- a/config/crd/bases/web.servers.org_webservers.yaml
+++ b/config/crd/bases/web.servers.org_webservers.yaml
@@ -40,6 +40,9 @@ spec:
                 description: The base for the names of the deployed application resources
                 pattern: ^[a-z]([-a-z0-9]*[a-z0-9])?$
                 type: string
+              persistentLogs:
+                description: If true operator will create a PVC to save the logs.
+                type: boolean
               replicas:
                 description: The desired number of replicas for the application
                 format: int32
@@ -73,7 +76,7 @@ spec:
                     type: object
                 type: object
               routeHostname:
-                description: Route behaviour:[TLS/tls]hostname/NONE or empty.
+                description: Route behaviour:[tls]hostname/NONE or empty.
                 type: string
               tlsPassword:
                 description: TLSPassword passphrase for the key in the client.key

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -12,4 +12,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: controller
-  newName: quay.io/jfclere/jws-operator
+  newName: quay.io/vmouriki/jws-operator

--- a/controllers/templates.go
+++ b/controllers/templates.go
@@ -3,6 +3,7 @@ package controllers
 import (
 	"strings"
 
+	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/util/intstr"
 
 	webserversv1alpha1 "github.com/web-servers/jws-operator/api/v1alpha1"
@@ -117,6 +118,37 @@ func (r *WebServerReconciler) generateConfigMapForDNS(webServer *webserversv1alp
 
 	controllerutil.SetControllerReference(webServer, cmap, r.Scheme)
 	return cmap
+}
+
+// logging.properties for saving logs to catalina.out inside the pod
+func (r *WebServerReconciler) generateConfigMapForLoggingProperties(webServer *webserversv1alpha1.WebServer) *corev1.ConfigMap {
+
+	cmap := &corev1.ConfigMap{
+		ObjectMeta: r.generateObjectMeta(webServer, "config-volume"),
+		Data:       r.generateLoggingProperties(webServer),
+	}
+
+	controllerutil.SetControllerReference(webServer, cmap, r.Scheme)
+	return cmap
+}
+
+// pvc for saving logs
+func (r *WebServerReconciler) generatePersistentVolumeClaimForLogging(webServer *webserversv1alpha1.WebServer) *corev1.PersistentVolumeClaim {
+
+	pvc := &corev1.PersistentVolumeClaim{
+		ObjectMeta: r.generateObjectMeta(webServer, "volume-pvc"),
+		Spec: corev1.PersistentVolumeClaimSpec{
+			AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
+			Resources: corev1.ResourceRequirements{
+				Requests: corev1.ResourceList{
+					corev1.ResourceName(corev1.ResourceStorage): resource.MustParse("1Gi"),
+				},
+			},
+		},
+	}
+
+	controllerutil.SetControllerReference(webServer, pvc, r.Scheme)
+	return pvc
 }
 
 // Custom build script for the pod builder
@@ -719,12 +751,32 @@ func (r *WebServerReconciler) generateEnvVars(webServer *webserversv1alpha1.WebS
 			Value: "/env/my-files/test.sh",
 		})
 	}
+	if webServer.Spec.PersistentLogs {
+		//custum logging.properties path
+		env = append(env, corev1.EnvVar{
+			Name:  "CATALINA_LOGGING_CONFIG",
+			Value: "-Djava.util.logging.config.file=/opt/operator_conf/logging.properties",
+		})
+	}
 	return env
 }
 
 // Create the VolumeMounts
 func (r *WebServerReconciler) generateVolumeMounts(webServer *webserversv1alpha1.WebServer) []corev1.VolumeMount {
 	var volm []corev1.VolumeMount
+
+	if webServer.Spec.PersistentLogs {
+		volm = append(volm, corev1.VolumeMount{
+			Name:      "config-volume",
+			MountPath: "/opt/operator_conf/logging.properties",
+			SubPath:   "logging.properties",
+		})
+		volm = append(volm, corev1.VolumeMount{
+			Name:      "volume-pvc",
+			MountPath: "/opt/tomcat_logs",
+		})
+	}
+
 	if webServer.Spec.UseSessionClustering {
 		volm = append(volm, corev1.VolumeMount{
 			Name:      "webserver-" + webServer.Name,
@@ -745,6 +797,28 @@ func (r *WebServerReconciler) generateVolumeMounts(webServer *webserversv1alpha1
 // Create the Volumes
 func (r *WebServerReconciler) generateVolumes(webServer *webserversv1alpha1.WebServer) []corev1.Volume {
 	var vol []corev1.Volume
+	if webServer.Spec.PersistentLogs {
+		vol = append(vol, corev1.Volume{
+			Name: "config-volume",
+			VolumeSource: corev1.VolumeSource{
+				ConfigMap: &corev1.ConfigMapVolumeSource{
+					LocalObjectReference: corev1.LocalObjectReference{
+						Name: "config-volume",
+					},
+				},
+			},
+		})
+
+		vol = append(vol, corev1.Volume{
+			Name: "volume-pvc",
+			VolumeSource: corev1.VolumeSource{
+				PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
+					ClaimName: "volume-pvc",
+				},
+			},
+		})
+	}
+
 	if webServer.Spec.UseSessionClustering {
 		vol = append(vol, corev1.Volume{
 			Name: "webserver-" + webServer.Name,
@@ -872,6 +946,22 @@ func (r *WebServerReconciler) generateCommandForServerXml(webServer *webserversv
 func (r *WebServerReconciler) generateCommandForBuider(script string) map[string]string {
 	cmd := make(map[string]string)
 	cmd["build.sh"] = script
+	return cmd
+}
+
+func (r *WebServerReconciler) generateLoggingProperties(webServer *webserversv1alpha1.WebServer) map[string]string {
+	cmd := make(map[string]string)
+	cmd["logging.properties"] = "handlers = java.util.logging.ConsoleHandler, 1catalina.org.apache.juli.AsyncFileHandler\n" +
+
+		".handlers = java.util.logging.ConsoleHandler, 1catalina.org.apache.juli.AsyncFileHandler\n" +
+
+		"java.util.logging.ConsoleHandler.level = FINE\n" +
+		"java.util.logging.ConsoleHandler.formatter = org.apache.juli.OneLineFormatter\n" +
+
+		"1catalina.org.apache.juli.AsyncFileHandler.level = FINE\n" +
+		"1catalina.org.apache.juli.AsyncFileHandler.directory = /opt/tomcat_logs\n" +
+		"1catalina.org.apache.juli.AsyncFileHandler.prefix = catalina.\n" +
+		"1catalina.org.apache.juli.AsyncFileHandler.maxDays = 90"
 	return cmd
 }
 

--- a/controllers/webserver_controller.go
+++ b/controllers/webserver_controller.go
@@ -242,6 +242,23 @@ func (r *WebServerReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 
 	}
 
+	if webServer.Spec.PersistentLogs {
+		// Check if exists a ConfigMap for the LoggingProperties otherwise create it.
+		configMap := r.generateConfigMapForLoggingProperties(webServer)
+		result, err = r.createConfigMap(ctx, webServer, configMap, configMap.Name, configMap.Namespace)
+		if err != nil || result != (ctrl.Result{}) {
+			return result, err
+		}
+
+		// Check if exists a PersistentVolumeClaim for logs otherwise create it.
+		persistentVolumeClaim := r.generatePersistentVolumeClaimForLogging(webServer)
+		result, err = r.createPersistentVolumeClaim(ctx, webServer, persistentVolumeClaim, persistentVolumeClaim.Name, persistentVolumeClaim.Namespace)
+		if err != nil || result != (ctrl.Result{}) {
+			return result, err
+		}
+
+	}
+
 	var foundReplicas int32
 	if webServer.Spec.WebImage != nil {
 


### PR DESCRIPTION
[Add] This MR adds to operator the ability to keep catalina.out logs inside a PeristentVolume even after pod terminates by using  PVC bounded to tomcat/logs directory. User have to set PersistentLogs true inside  WebServerSpec to achieve this. Of course PV's (created by cluster administrators) need to have "retain" reclaim policy in order to keep the logs after pod unclaim the PV, otherwise PV will delete the data after the unclaim. Afterwards through this catalina.out logs can be printed via operator with further implementation.

Signed-off: [vmouriki@redhat.com](mailto:vmouriki@redhat.com)