### PR TITLE
JWS-2416 fixes

### DIFF
--- a/api/v1alpha1/webserver_types.go
+++ b/api/v1alpha1/webserver_types.go
@@ -22,8 +22,10 @@ type WebServerSpec struct {
 	Replicas int32 `json:"replicas"`
 	// Use Session Clustering
 	UseSessionClustering bool `json:"useSessionClustering,omitempty"`
-	// Route behaviour:[TLS/tls]hostname/NONE or empty.
+	// Route behaviour:[tls]hostname/NONE or empty.
 	RouteHostname string `json:"routeHostname,omitempty"`
+	// certificateVerification for tomcat configuration: required/optional or empty.
+	CertificateVerification string `json:"certificateVerification,omitempty"`
 	// TLSSecret secret containing server.cert the server certificate, server.key the server key and optional ca.cert the CA cert of the client certificates
 	TLSSecret string `json:"tlsSecret,omitempty"`
 	// TLSPassword passphrase for the key in the client.key

--- a/config/crd/bases/web.servers.org_webservers.yaml
+++ b/config/crd/bases/web.servers.org_webservers.yaml
@@ -40,6 +40,10 @@ spec:
                 description: The base for the names of the deployed application resources
                 pattern: ^[a-z]([-a-z0-9]*[a-z0-9])?$
                 type: string
+              certificateVerification:
+                description: 'certificateVerification for tomcat configuration: required/optional
+                  or empty.'
+                type: string
               replicas:
                 description: The desired number of replicas for the application
                 format: int32
@@ -73,7 +77,7 @@ spec:
                     type: object
                 type: object
               routeHostname:
-                description: Route behaviour:[TLS/tls]hostname/NONE or empty.
+                description: Route behaviour:[tls]hostname/NONE or empty.
                 type: string
               tlsPassword:
                 description: TLSPassword passphrase for the key in the client.key

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -154,6 +154,13 @@ rules:
   - list
   - watch
 - apiGroups:
+  - route.openshift.io
+  resources:
+  - routes/custom-host
+  verbs:
+  - create
+  - get
+- apiGroups:
   - web.servers.org
   resources:
   - webservers

--- a/controllers/webserver_controller.go
+++ b/controllers/webserver_controller.go
@@ -102,6 +102,7 @@ type WebServerReconciler struct {
 // +kubebuilder:rbac:groups=apps.openshift.io,resources=deploymentconfigs,verbs=create;get;list;delete
 
 // +kubebuilder:rbac:groups=route.openshift.io,resources=routes,verbs=create;get;list;delete;watch
+// +kubebuilder:rbac:groups=route.openshift.io,resources=routes/custom-host,verbs=create;get;
 
 // +kubebuilder:rbac:groups=web.servers.org,resources=webservers,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=web.servers.org,resources=webservers/status,verbs=get;update;patch
@@ -176,7 +177,7 @@ func (r *WebServerReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 
 	// Check if a Service for routing already exists, and if not create a new one
 	routingService := &corev1.Service{}
-	if strings.HasPrefix(webServer.Spec.RouteHostname, "TLS") || strings.HasPrefix(webServer.Spec.RouteHostname, "tls") {
+	if strings.HasPrefix(webServer.Spec.RouteHostname, "tls") {
 		log.Info("generating routing service with port 8443 " + "cause webServer.Spec.RouteHostname= " + webServer.Spec.RouteHostname)
 		routingService = r.generateRoutingService(webServer, 8443)
 	} else {
@@ -497,7 +498,7 @@ func (r *WebServerReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 
 	if r.isOpenShift {
 
-		if webServer.Spec.RouteHostname != "NONE" && (!strings.HasPrefix(webServer.Spec.RouteHostname, "TLS") && !strings.HasPrefix(webServer.Spec.RouteHostname, "tls")) {
+		if webServer.Spec.RouteHostname != "NONE" && !strings.HasPrefix(webServer.Spec.RouteHostname, "tls") {
 
 			// Check if a Route already exists, and if not create a new one
 			route := r.generateRoute(webServer)
@@ -517,7 +518,7 @@ func (r *WebServerReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 				webServer.Status.Hosts = hosts
 				log.Info("Status.Hosts update scheduled")
 			}
-		} else if strings.HasPrefix(webServer.Spec.RouteHostname, "TLS") || strings.HasPrefix(webServer.Spec.RouteHostname, "tls") {
+		} else if strings.HasPrefix(webServer.Spec.RouteHostname, "tls") {
 			// Check if a Route already exists, and if not create a new one
 			route := r.generateSecureRoute(webServer)
 			result, err = r.createRoute(ctx, webServer, route, route.Name, route.Namespace)


### PR DESCRIPTION
Add the ability to change route's host  as described in [JWS-2416](https://issues.redhat.com/browse/JWS-2416).
Removed the unnecessary "TLS" option for  RouteHostname.
Added CertificateVerification in order to give user the ability to chose how to configure the connector 

Signed-off: [vmouriki@redhat.com](mailto:vmouriki@redhat.com)