### PR TITLE
tomcat access logs

### DIFF
--- a/api/v1alpha1/webserver_types.go
+++ b/api/v1alpha1/webserver_types.go
@@ -38,6 +38,8 @@ type WebServerSpec struct {
 	Resources *corev1.ResourceRequirements `json:"resources,omitempty"`
 	//If true operator will create a PVC to save the logs.
 	PersistentLogs bool `json:"persistentLogs,omitempty"`
+	//If true operator will log tomcat's access logs
+	EnableAccessLogs bool `json:"enableAccessLogs,omitempty"`
 }
 
 // (Deployment method 1) Application image

--- a/config/crd/bases/web.servers.org_webservers.yaml
+++ b/config/crd/bases/web.servers.org_webservers.yaml
@@ -40,13 +40,16 @@ spec:
                 description: The base for the names of the deployed application resources
                 pattern: ^[a-z]([-a-z0-9]*[a-z0-9])?$
                 type: string
-              persistentLogs:
-                description: If true operator will create a PVC to save the logs.
-                type: boolean
               certificateVerification:
                 description: 'certificateVerification for tomcat configuration: required/optional
                   or empty.'
                 type: string
+              enableAccessLogs:
+                description: If true operator will log tomcat's access logs
+                type: boolean
+              persistentLogs:
+                description: If true operator will create a PVC to save the logs.
+                type: boolean
               replicas:
                 description: The desired number of replicas for the application
                 format: int32

--- a/controllers/templates.go
+++ b/controllers/templates.go
@@ -773,6 +773,12 @@ func (r *WebServerReconciler) generateEnvVars(webServer *webserversv1alpha1.WebS
 			Value: value,
 		},
 	}
+	if webServer.Spec.EnableAccessLogs {
+		env = append(env, corev1.EnvVar{
+			Name:  "ENABLE_ACCESS_LOG",
+			Value: "true",
+		})
+	}
 	if webServer.Spec.UseSessionClustering {
 		// Add parameter USE_SESSION_CLUSTERING
 		env = append(env, corev1.EnvVar{
@@ -965,6 +971,18 @@ func (r *WebServerReconciler) generateCommandForServerXml(webServer *webserversv
 			"if [ $? -ne 0 ]; then\n" +
 			"  sed -i '/cluster.html/a        <Cluster className=\"org.apache.catalina.ha.tcp.SimpleTcpCluster\" channelSendOptions=\"6\">\\n <Channel className=\"org.apache.catalina.tribes.group.GroupChannel\">\\n <Membership className=\"org.apache.catalina.tribes.membership.cloud.CloudMembershipService\" membershipProviderClassName=\"org.apache.catalina.tribes.membership.cloud.KubernetesMembershipProvider\"/>\\n </Channel>\\n </Cluster>\\n' ${FILE}\n" +
 			"fi\n" + connector
+		if webServer.Spec.EnableAccessLogs {
+			cmd["test.sh"] = cmd["test.sh"] + "grep -q directory='\"/proc/self/fd\"' ${FILE}\n" +
+				"if [ $? -eq 0 ]; then\n" +
+				"sed -i 's|directory=\"/proc/self/fd\"|directory=\"/opt/tomcat_logs\"|g' ${FILE}\n" +
+				"sed -i \"s|prefix=\\\"1\\\"|prefix=\\\"access-$HOSTNAME\\\"|g\" ${FILE}\n" +
+				"sed -i 's|suffix=\"\"|suffix=\".log\"|g' ${FILE}\n" +
+				"else\n" +
+				"sed -i 's|directory=\"logs\"|directory=\"/opt/tomcat_logs\"|g' ${FILE}\n" +
+				"sed -i \"s|prefix=\\\"localhost_access_log\\\"|prefix=\\\"access-$HOSTNAME\\\"|g\" ${FILE}\n" +
+				"sed -i 's|suffix=\".txt\"|suffix=\".log\"|g' ${FILE}\n" +
+				"fi\n"
+		}
 	} else {
 		cmd["test.sh"] = "FILE=`find /opt -name server.xml`\n" +
 			"if [ -z \"${FILE}\" ]; then\n" +
@@ -974,6 +992,18 @@ func (r *WebServerReconciler) generateCommandForServerXml(webServer *webserversv
 			"if [ $? -ne 0 ]; then\n" +
 			"  sed -i '/cluster.html/a        <Cluster className=\"org.apache.catalina.ha.tcp.SimpleTcpCluster\" channelSendOptions=\"6\">\\n <Channel className=\"org.apache.catalina.tribes.group.GroupChannel\">\\n <Membership className=\"org.apache.catalina.tribes.membership.cloud.CloudMembershipService\" membershipProviderClassName=\"org.apache.catalina.tribes.membership.cloud.DNSMembershipProvider\"/>\\n </Channel>\\n </Cluster>\\n' ${FILE}\n" +
 			"fi\n" + connector
+		if webServer.Spec.EnableAccessLogs {
+			cmd["test.sh"] = cmd["test.sh"] + "grep -q directory='\"/proc/self/fd\"' ${FILE}\n" +
+				"if [ $? -eq 0 ]; then\n" +
+				"sed -i 's|directory=\"/proc/self/fd\"|directory=\"/opt/tomcat_logs\"|g' ${FILE}\n" +
+				"sed -i \"s|prefix=\\\"1\\\"|prefix=\\\"access-$HOSTNAME\\\"|g\" ${FILE}\n" +
+				"sed -i 's|suffix=\"\"|suffix=\".log\"|g' ${FILE}\n" +
+				"else\n" +
+				"sed -i 's|directory=\"logs\"|directory=\"/opt/tomcat_logs\"|g' ${FILE}\n" +
+				"sed -i \"s|prefix=\\\"localhost_access_log\\\"|prefix=\\\"access-$HOSTNAME\\\"|g\" ${FILE}\n" +
+				"sed -i 's|suffix=\".txt\"|suffix=\".log\"|g' ${FILE}\n" +
+				"fi\n"
+		}
 	}
 	return cmd
 }


### PR DESCRIPTION
[Add] If this variable is set to true operator will configure tomcat printing access logs in /opt/tomcat_logs path inside the pod (like catalina.out). 

Signed-off: [vmouriki@redhat.com](mailto:vmouriki@redhat.com)