### PR TITLE
asf image compatibility

### DIFF
--- a/api/v1alpha1/webserver_types.go
+++ b/api/v1alpha1/webserver_types.go
@@ -40,6 +40,8 @@ type WebServerSpec struct {
 	PersistentLogs bool `json:"persistentLogs,omitempty"`
 	//If true operator will log tomcat's access logs
 	EnableAccessLogs bool `json:"enableAccessLogs,omitempty"`
+	// IsNotJWS boolean that specifies if the image is JWS or not.
+	IsNotJWS bool `json:"isNotJWS,omitempty"`
 }
 
 // (Deployment method 1) Application image

--- a/config/crd/bases/web.servers.org_webservers.yaml
+++ b/config/crd/bases/web.servers.org_webservers.yaml
@@ -47,6 +47,10 @@ spec:
               enableAccessLogs:
                 description: If true operator will log tomcat's access logs
                 type: boolean
+              isNotJWS:
+                description: IsNotJWS boolean that specifies if the image is JWS or
+                  not.
+                type: boolean
               persistentLogs:
                 description: If true operator will create a PVC to save the logs.
                 type: boolean

--- a/controllers/webserver_controller.go
+++ b/controllers/webserver_controller.go
@@ -234,6 +234,15 @@ func (r *WebServerReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 
 		}
 
+		if webServer.Spec.IsNotJWS {
+			// Check if exists a ConfigMap for ASF image start otherwise create it.
+			configMap := r.generateConfigMapForASFStart(webServer)
+			result, err = r.createConfigMap(ctx, webServer, configMap, configMap.Name, configMap.Namespace)
+			if err != nil || result != (ctrl.Result{}) {
+				return result, err
+			}
+		}
+
 		// Check if exists a ConfigMap for the server.xml <Cluster/> definition otherwise create it.
 		configMap := r.generateConfigMapForDNS(webServer)
 		result, err = r.createConfigMap(ctx, webServer, configMap, configMap.Name, configMap.Namespace)


### PR DESCRIPTION
[Add] logic to automatically configure any tomcat image in order to support persistent logs feature. With the addition of webserver's "IsNotJWS" variable operator can figure out how to configure the given image for deployment (ASF or JWS image) by adding a starts script config map in the case that the image is not the JWS one. Moreover made test.sh script simpler by removing repeating code.

Cotnributes to: https://github.com/web-servers/jws-operator/issues/116

Signed-off: [vmouriki@redhat.com](mailto:vmouriki@redhat.com)
