### PR TITLE
Gitignore extention about files which are created during the build.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+config/manifests/bases/*
+bundle/*
+bundle.Dockerfile
 
 # Binaries for programs and plugins
 *.exe


### PR DESCRIPTION
Gitignore extention about files which are created during the build.